### PR TITLE
星座ごとの人数のグラフを表示できるようにした

### DIFF
--- a/routes/index.py
+++ b/routes/index.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, render_template, request, redirect, url_for
 from models import Prefecture
+from routes import zodiac
 
 # Blueprintの作成
 index_bp = Blueprint('index', __name__, url_prefix='')
@@ -9,5 +10,13 @@ index_bp = Blueprint('index', __name__, url_prefix='')
 def list():
     # データ取得
     prefectures = Prefecture.select()
+    counts = zodiac.count_birthdays_by_month()
+    labels = [i for i in range(1, 13)]  # または list(range(1, 13))
+    data = [counts[month] for month in labels]
+    zodiac_cntdata = zodiac.count_zodiacs()
     
-    return render_template('index.html', prefectures = prefectures)
+    return render_template('index.html',
+                            prefectures = prefectures,
+                            labels=labels,
+                            data=data,
+                            zodiac_cntdata=zodiac_cntdata)

--- a/routes/zodiac.py
+++ b/routes/zodiac.py
@@ -48,3 +48,60 @@ def edit(zodiac_birthday):
 
     return render_template('zodiac_edit.html', zodiac=zodiac)
 
+
+@zodiac_bp.route('/graph/month')
+def graph_month():
+    counts = count_birthdays_by_month()
+    labels = [i for i in range(1, 13)]  # または list(range(1, 13))
+    data = [counts[month] for month in labels]
+    zodiac_cntdata = count_zodiacs()
+    return render_template('zodiac_graph_month.html',
+                         labels=labels,
+                         data=data,
+                         zodiac_cntdata=zodiac_cntdata)
+
+
+def count_zodiacs():
+    zodiac_counts = [0] * 13
+    for zodiac in Zodiac.select():
+        judge_zodiac = zodiac.zodiac_signs
+        if judge_zodiac == '牡羊座' or judge_zodiac == 'おひつじ座':
+            zodiac_counts[0] += 1
+
+        elif judge_zodiac == '牡牛座' or judge_zodiac == 'おうし座':
+            zodiac_counts[1] += 1
+
+        elif judge_zodiac == '双子座' or judge_zodiac == 'ふたご座':
+            zodiac_counts[2] += 1
+
+        elif judge_zodiac == '蟹座' or judge_zodiac == 'かに座':
+            zodiac_counts[3] += 1
+
+        elif judge_zodiac == '獅子座' or judge_zodiac == 'しし座':
+            zodiac_counts[4] += 1
+
+        elif judge_zodiac == '乙女座' or judge_zodiac == 'おとめ座':
+            zodiac_counts[5] += 1
+
+        elif judge_zodiac == '天秤座' or judge_zodiac == 'てんびん座':
+            zodiac_counts[6] += 1
+
+        elif judge_zodiac == '蠍座' or judge_zodiac == 'さそり座':
+            zodiac_counts[7] += 1
+
+        elif judge_zodiac == '射手座' or judge_zodiac == 'いて座':
+            zodiac_counts[8] += 1
+
+        elif judge_zodiac == '山羊座' or judge_zodiac == 'やぎ座':
+            zodiac_counts[9] += 1
+
+        elif judge_zodiac == '水瓶座' or judge_zodiac == 'みずがめ座':
+            zodiac_counts[10] += 1
+
+        elif judge_zodiac == '魚座' or judge_zodiac == 'うお座':
+            zodiac_counts[11] += 1
+
+        else:
+            zodiac_counts[12] += 1
+
+    return zodiac_counts

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
     <ul>
       <li><a href="{{ url_for('name.list') }}">名前リスト</a></li>
       <li><a href="{{ url_for('zodiac.list') }}">生年月日リスト</a></li>
+      <li><a href="{{ url_for('zodiac.graph_month') }}">月別誕生日統計</a></li>
     </ul>
     <canvas id="prefecture"></canvas>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.js"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,9 +10,20 @@
     <ul>
       <li><a href="{{ url_for('name.list') }}">名前リスト</a></li>
       <li><a href="{{ url_for('zodiac.list') }}">生年月日リスト</a></li>
-      <li><a href="{{ url_for('zodiac.graph_month') }}">月別誕生日統計</a></li>
     </ul>
     <canvas id="prefecture"></canvas>
+    <div class="container">
+        <h2>月別誕生日統計</h2>
+        {% if data %}
+            <div class="chart-container">
+                <canvas id="monthlyChart"></canvas>
+            </div>
+        {% else %}
+            <p>データが存在しません。</p>
+        {% endif %}
+    </div>
+    <h2>星座別人数統計</h2>
+    <canvas id="zodiacChart"></canvas>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.js"></script>
     <script type="text/javascript">
       // Pythonから渡されたデータをJavaScriptで使う
@@ -51,6 +62,76 @@
           }
         }
       );
+
+      try {
+    const ctx = document.getElementById('monthlyChart');
+    const graphData = JSON.parse('{{ data | tojson | safe }}');
+    const graphLabels = JSON.parse('{{ labels | tojson | safe }}');
+
+    if (graphData && graphLabels) {
+        new Chart(ctx, {
+            type: 'bar',  // グラフの種類を指定
+            data: {
+                labels: graphLabels.map(month => `${month}月`),
+                datasets: [{
+                    label: '誕生日の数',
+                    data: graphData,
+                    backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                    borderColor: 'rgba(54, 162, 235, 1)',
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                responsive: true,
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        ticks: {
+                            stepSize: 1
+                        }
+                    }
+                }
+            }
+        });
+    }
+} catch (error) {
+    console.error('グラフの描画に失敗しました:', error);
+}
+
+  var ctx = document.getElementById("zodiacChart");
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: ['牡羊座', '牡牛座', '双子座', '蟹座', '獅子座', '乙女座', '天秤座', '蠍座', '射手座', '山羊座', '水瓶座', '魚座', '分類不可'],
+      datasets: [{
+        label: '人数',
+        data: {{zodiac_cntdata}},
+        backgroundColor: [
+          'rgba(235, 97, 0, 0.2)',
+          'rgba(252, 200, 0, 0.2)',
+          'rgba(207, 219, 0, 0.2)',
+          'rgba(34, 172, 56, 0.2)',
+          'rgba(0, 155, 107, 0.2)',
+          'rgba(0, 160, 193, 0.2)',
+          'rgba(0, 134, 209, 0.2)',
+          'rgba(0, 71, 157, 0.2)',
+          'rgba(96, 25, 134, 0.2)',
+          'rgba(190, 0, 129, 0.2)',
+          'rgba(229, 0, 106, 0.2)',
+          'rgba(150, 150, 150, 0.2)'
+        ]
+      }]
+    },
+    options: {
+      scales: {
+        y: {
+          ticks: {
+            stepSize: 1
+          }
+        }
+      }
+    }
+  });
     </script>
 </body>
 </html>

--- a/templates/zodiac_graph_month.html
+++ b/templates/zodiac_graph_month.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>月別誕生日統計 - グラフ</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='base-style.css') }}">
+</head>
+<body>
+    <ul class="breadcrumb">
+        <li><a href="{{ url_for('index') }}">HOME</a></li>
+        <li><a href="{{ url_for('zodiac.list') }}">星座別誕生月グラフ</a></li>
+    </ul>
+   
+    <div class="container">
+        <h2>月別誕生日統計</h2>
+        {% if data %}
+            <div class="chart-container">
+                <canvas id="monthlyChart"></canvas>
+            </div>
+        {% else %}
+            <p>データが存在しません。</p>
+        {% endif %}
+    </div>
+    <h2>星座別人数統計</h2>
+    <canvas id="zodiacChart"></canvas>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+try {
+    const ctx = document.getElementById('monthlyChart');
+    const graphData = JSON.parse('{{ data | tojson | safe }}');
+    const graphLabels = JSON.parse('{{ labels | tojson | safe }}');
+
+    if (graphData && graphLabels) {
+        new Chart(ctx, {
+            type: 'bar',  // グラフの種類を指定
+            data: {
+                labels: graphLabels.map(month => `${month}月`),
+                datasets: [{
+                    label: '誕生日の数',
+                    data: graphData,
+                    backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                    borderColor: 'rgba(54, 162, 235, 1)',
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                responsive: true,
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        ticks: {
+                            stepSize: 1
+                        }
+                    }
+                }
+            }
+        });
+    }
+} catch (error) {
+    console.error('グラフの描画に失敗しました:', error);
+}
+
+  var ctx = document.getElementById("zodiacChart");
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: ['牡羊座', '牡牛座', '双子座', '蟹座', '獅子座', '乙女座', '天秤座', '蠍座', '射手座', '山羊座', '水瓶座', '魚座', '分類不可'],
+      datasets: [{
+        label: '人数',
+        data: {{zodiac_cntdata}},
+        backgroundColor: [
+            'rgba(235, 97, 0, 0.2)',
+            'rgba(252, 200, 0, 0.2)',
+            'rgba(207, 219, 0, 0.2)',
+            'rgba(34, 172, 56, 0.2)',
+            'rgba(0, 155, 107, 0.2)',
+            'rgba(0, 160, 193, 0.2)',
+            'rgba(0, 134, 209, 0.2)',
+            'rgba(0, 71, 157, 0.2)',
+            'rgba(96, 25, 134, 0.2)',
+            'rgba(190, 0, 129, 0.2)',
+            'rgba(229, 0, 106, 0.2)',
+            'rgba(150, 150, 150, 0.2)'
+        ]
+      }]
+    },
+    options: {
+        scales: {
+            y: {
+                ticks: {
+                    stepSize: 1
+                }
+            }
+        }
+    }
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
zodiac_graph_month.htmlと同じ場所にグラフを表示できるようにしました
indexの月別誕生日統計からアクセスできます
牡牛座 または おうし座 のように漢字またはひらがな＋座が表記がカウント対象です
確認次第index.htmlで表示できるように修正します