### PR TITLE
月別誕生日統計のグラフが正常に表示されるように修正

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -62,7 +62,10 @@
           }
         }
       );
+    </script>
 
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
       try {
     const ctx = document.getElementById('monthlyChart');
     const graphData = JSON.parse('{{ data | tojson | safe }}');
@@ -97,7 +100,10 @@
 } catch (error) {
     console.error('グラフの描画に失敗しました:', error);
 }
+</script>
 
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.js"></script>
+<script type="text/javascript">
   var ctx = document.getElementById("zodiacChart");
   new Chart(ctx, {
     type: 'bar',


### PR DESCRIPTION
月別誕生日統計のグラフでy軸が1以上しか表示されていなかったので、0以上から表示されるように修正しました
月別誕生日統計のみ別のライブラリを使用していたため、都度ライブラリを切り替えて対応しました